### PR TITLE
Clang doesn't compile if no parenthesis for `&&` and `||` logical order

### DIFF
--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -157,7 +157,7 @@ size_t JsonWriteRichPresenceObj(char* dest,
                     WriteOptionalString(writer, "join", presence->joinSecret);
                     WriteOptionalString(writer, "spectate", presence->spectateSecret);
                 } else {
-                    if (presence->button_url[0] && presence->button_label[0] || presence->button_url[1] && presence->button_label[1]) {
+                    if ((presence->button_url[0] && presence->button_label[0]) || (presence->button_url[1] && presence->button_label[1])) {
                         WriteArray buttons(writer, "buttons");
 
                         if (presence->button_url[0] && presence->button_label[0]) {


### PR DESCRIPTION
Note that [this StackOverflow answer](https://stackoverflow.com/a/68335748/7123660) helps us to better understand [`discord/discord-rpc`](https://github.com/discord/discord-rpc) forks.